### PR TITLE
Added watcher for staleness

### DIFF
--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -6,6 +6,7 @@ import threading
 from blinker.base import Namespace
 
 from . import data
+from . import watcher
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,16 @@ class LiveData(object):
         stream = self._db.child(self._root_path).stream(self._stream_handler)
         self._streams[id(stream)] = stream
         self._start_stream_gc()
+        watcher.watch(
+            id(self),
+            self.is_stale,
+            self.restart,
+            interval=self._ttl
+        )
+
+    def restart(self):
+        self.reset()
+        self.get_data()
 
     def reset(self):
         logger.debug('Resetting all data')

--- a/firebasedata/watcher.py
+++ b/firebasedata/watcher.py
@@ -1,0 +1,92 @@
+import datetime
+import logging
+from threading import Timer
+
+DEFAULT_INTERVAL = datetime.timedelta(minutes=30)
+
+_watchers = {}
+logger = logging.getLogger(__name__)
+
+
+class Watcher:
+    def __init__(self, should_update, update_func, interval=None):
+        self._should_update = should_update
+        self._update_func = update_func
+        self._interval = DEFAULT_INTERVAL if interval is None else interval
+        self._should_cancel = False
+        self.running = False
+
+    def start(self):
+        if self._should_cancel:
+            logger.warning('Cannot start cancelled watcher: %s', id(self))
+            return
+
+        if self.running:
+            logger.debug('Watcher already running: %s', id(self))
+            return
+
+        self._timer = Timer(self._interval.total_seconds(), self._action)
+        self._timer.daemon = True
+        self._timer.start()
+        self.running = True
+
+    def _action(self):
+        if self._should_cancel:
+            logger.debug('Stopping cancelled watcher: %s', id(self))
+            self.running = False
+            return
+
+        logger.debug(
+            'Watcher (%s) checking if update is requested: %s',
+            id(self),
+            self._should_update
+        )
+        if self._should_update():
+            logger.debug(
+                'Update requested. Watcher (%s) updating: %s',
+                id(self),
+                self._update_func
+            )
+            self._update_func()
+        # Mark this timer as complete, and start a new timer
+        self.running = False
+        self.start()
+
+    def cancel(self):
+        self._should_cancel = True
+
+
+def watch(name, should_update, update_func, interval=None):
+    """Watch something and call a function when it should be updated.
+
+    Arguments:
+        should_update: Callable that returns True if the thing being watched
+            should be updated, or False otherwise.
+        update_func: Callable that updates the thing being watched when {should_update}
+            returns True. Watching and updating occurs in a separate thread,
+            so ensure this function is threadsafe.
+        interval: datetime.timedelta indicating how often to poll {should_update}.
+
+    Returns: A callable that will stop all watchers.
+    """
+    watcher = Watcher(should_update, update_func, interval)
+    _watchers[name] = watcher
+    watcher.start()
+
+
+def cancel(name):
+    if name not in _watchers:
+        return None
+    watcher = _watchers[name]
+    if watcher:
+        logger.debug('Cancelling watcher: %s (%s)', name, id(watcher))
+        watcher.cancel()
+    del _watchers[name]
+    return True
+
+
+def cancel_all():
+    logger.debug('Stopping all watchers')
+    for watcher in _watchers.values():
+        watcher.cancel()
+    _watchers.clear()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FirebaseData',
-    version='0.2',
+    version='0.3',
     packages=find_packages(),
     install_requires=[
         'blinker>=1.4',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os.path
+import logging
 import sys
 
 # Add the module path
@@ -7,3 +8,8 @@ module_path = os.path.abspath(os.path.join(
     '..'
 ))
 sys.path.insert(0, module_path)
+
+logging.basicConfig(
+    format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+    level=logging.DEBUG
+)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -165,6 +165,18 @@ class Test_listen:
         assert stream_id in livedata._streams
         assert livedata._streams[stream_id] is stream
 
+    def test_watcher_is_started(self, livedata, mocker):
+        watch_mock = mocker.patch('firebasedata.watcher.watch')
+
+        livedata.listen()
+
+        watch_mock.assert_called_with(
+            id(livedata),
+            livedata.is_stale,
+            livedata.restart,
+            interval=livedata._ttl
+        )
+
     def test_stream_gc_is_started(self, livedata, mocker):
         livedata._start_stream_gc = mocker.Mock()
         livedata.listen()
@@ -184,6 +196,20 @@ class Test_reset:
         livedata.reset()
 
         assert livedata._cache is None
+
+
+class Test_restart:
+    def test_calls_reset(self, livedata, mocker):
+        livedata.reset = mocker.Mock()
+        livedata.restart()
+
+        assert livedata.reset.called
+
+    def test_resets_get_data(self, livedata, mocker):
+        livedata.get_data = mocker.Mock()
+        livedata.restart()
+
+        assert livedata.get_data.called
 
 
 class Test_hangup:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -38,6 +38,16 @@ def test_Watcher_start(watcher_stub, timer_fake):
     assert timer_fake.return_value.start.called
 
 
+def test_Watcher_cannot_start_while_running(watcher_stub, log_mock):
+    watcher_stub.start()
+    watcher_stub.start()
+
+    log_mock.debug.assert_called_with(
+        'Watcher already running: %s',
+        id(watcher_stub)
+    )
+
+
 def test_Watcher_cancel(watcher_stub):
     watcher_stub.cancel()
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,163 @@
+from datetime import timedelta
+import time
+
+import pytest
+
+from firebasedata import watcher
+
+
+@pytest.fixture
+def log_mock(mocker):
+    return mocker.patch('firebasedata.watcher.logger')
+
+
+@pytest.fixture
+def timer_fake(mocker):
+    return  mocker.patch('firebasedata.watcher.Timer')
+
+
+@pytest.fixture
+def watcher_stub(mocker, timer_fake):
+    is_stale = mocker.Mock()
+    update = mocker.Mock()
+    interval = timedelta(seconds=.001)
+    return watcher.Watcher(is_stale, update, interval)
+
+
+def test_Watcher_init(watcher_stub, timer_fake):
+    assert watcher_stub.running is False
+    assert not timer_fake.called
+
+
+def test_Watcher_start(watcher_stub, timer_fake):
+    watcher_stub.start()
+
+    assert watcher_stub._should_cancel is False
+    assert watcher_stub.running is True
+    assert timer_fake.called
+    assert timer_fake.return_value.start.called
+
+
+def test_Watcher_cancel(watcher_stub):
+    watcher_stub.cancel()
+
+    assert watcher_stub._should_cancel is True
+
+
+def test_Watcher_cannot_start_after_cancel(watcher_stub, log_mock):
+    watcher_stub.cancel()
+    watcher_stub.start()
+
+    log_mock.warning.assert_called_with(
+        'Cannot start cancelled watcher: %s',
+        id(watcher_stub)
+    )
+
+
+def test_Watcher_action__not_stale(mocker, watcher_stub):
+    watcher_stub._should_update.return_value = False
+    watcher_stub.start = mocker.Mock()
+    watcher_stub._should_cancel = False
+    watcher_stub._action()
+
+    assert watcher_stub._should_update.called
+    assert not watcher_stub._update_func.called
+    assert watcher_stub.start.called
+
+
+def test_Watcher_action__stale(mocker, watcher_stub):
+    watcher_stub._should_update.return_value = True
+    watcher_stub.start = mocker.Mock()
+    watcher_stub._should_cancel = False
+    watcher_stub._action()
+
+    assert watcher_stub._should_update.called
+    assert watcher_stub._update_func.called
+    assert watcher_stub.start.called
+
+
+def test_Watcher_action__should_cancel(mocker, watcher_stub):
+    watcher_stub.start = mocker.Mock()
+    watcher_stub._should_cancel = True
+    watcher_stub._action()
+
+    assert not watcher_stub._should_update.called
+    assert not watcher_stub._update_func.called
+    assert not watcher_stub.start.called
+
+
+def test_watch(mocker):
+    watcher_stub = mocker.patch('firebasedata.watcher.Watcher')
+    is_stale = mocker.Mock()
+    update = mocker.Mock()
+    interval = timedelta(seconds=.001)
+
+    watcher.watch('test_watcher', is_stale, update, interval)
+
+    watcher_stub.assert_called_with(is_stale, update, interval)
+    assert watcher_stub.return_value.start.called
+    assert 'test_watcher' in watcher._watchers
+
+
+def test_cancel__unknown_name(mocker):
+    result = watcher.cancel('whatever')
+
+    assert result is None
+
+
+def test_cancel__known_name(mocker):
+    watcher_stub = mocker.Mock()
+    watcher._watchers['something'] = watcher_stub
+    result = watcher.cancel('something')
+
+    assert result is True
+    assert watcher_stub.cancel.called
+
+
+def test_cancel_all(mocker):
+    watcher_stub1 = mocker.Mock()
+    watcher_stub2 = mocker.Mock()
+    watcher._watchers['watcher1'] = watcher_stub1
+    watcher._watchers['watcher2'] = watcher_stub2
+
+    watcher.cancel_all()
+
+    assert watcher_stub1.cancel.called
+    assert watcher_stub2.cancel.called
+    assert not watcher._watchers
+
+
+def test_watch__not_stale(mocker):
+    is_stale = mocker.Mock()
+    is_stale.side_effect = [
+        False,
+        False,
+        False,
+    ]
+    update = mocker.Mock()
+    interval = timedelta(seconds=.001)
+
+    watcher.watch('test_watcher', is_stale, update, interval=interval)
+    time.sleep(.1)
+    watcher.cancel('test_watcher')
+
+    assert is_stale.call_count == 4
+    assert update.called is False
+
+
+def test_watch__stale(mocker):
+    is_stale = mocker.Mock()
+    is_stale.side_effect = [
+        False,
+        False,
+        True,
+    ]
+    update = mocker.Mock()
+    interval = timedelta(seconds=.001)
+
+    watcher.watch('test_watcher', is_stale, update, interval=interval)
+    time.sleep(.1)
+    watcher.cancel('test_watcher')
+
+    assert is_stale.call_count == 4
+    assert update.called is True


### PR DESCRIPTION
This adds a thread-based watcher to periodically check for data staleness, and restart the SSE connection if needed.