### PR TITLE
Fix bug with empty data triggering is_stale check

### DIFF
--- a/firebasedata/data.py
+++ b/firebasedata/data.py
@@ -27,9 +27,6 @@ def normalize_path(path):
 class FirebaseData(dict):
     last_updated_at = None
 
-    def _set_last_updated(self):
-        self.last_updated_at = datetime.datetime.utcnow()
-
     def __init__(self, *args, **kwargs):
         self._set_last_updated()
 
@@ -42,6 +39,9 @@ class FirebaseData(dict):
                 self._default_value = initial
             else:
                 raise
+
+    def _set_last_updated(self):
+        self.last_updated_at = datetime.datetime.utcnow()
 
     def get_node_for_path(self, path):
         keys = get_path_list(path)

--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -51,8 +51,8 @@ class LiveData(object):
             return False
 
         data = self.get_data()
-        if not data or not data.last_updated_at:
-            logger.debug('Data is stale: %s', data)
+        if data is None or data.last_updated_at is None:
+            logger.debug('Data is invalid: %s', data)
             return True
 
         stale = datetime.datetime.utcnow() - data.last_updated_at > self._ttl

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FirebaseData',
-    version='0.3',
+    version='0.4',
     packages=find_packages(),
     install_requires=[
         'blinker>=1.4',

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -100,6 +100,20 @@ class Test_is_stale:
 
         assert result is True
 
+    def test_empty_data(self, livedata, mocker):
+        livedata.get_data = mocker.Mock(return_value=data.FirebaseData())
+
+        result = livedata.is_stale()
+
+        assert result is False
+
+    def test_no_default_data(self, livedata, mocker):
+        livedata.get_data = mocker.Mock(return_value=data.FirebaseData(None))
+
+        result = livedata.is_stale()
+
+        assert result is False
+
     def test_missing_data_last_updated_at(self, livedata, mocker):
         livedata.get_data = mocker.Mock(**{'return_value.last_updated_at': None})
 


### PR DESCRIPTION
If `FirebaseData` contained no keys, either because it was completely empty, or because it only had a default value, this was triggering `LiveData.is_stale` to think the instance was completely missing. This is because Python considers dictionaries to be falsey if they have no keys, and `FirebaseData` inherits from `dict`.

This fixes that bug.