### PR TITLE
Normalize paths when interacting with signals

### DIFF
--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -62,8 +62,9 @@ class LiveData(object):
             logger.debug('Data is fresh: %s', data)
         return stale
 
-    def signal(self, *args, **kwargs):
-        return self.events.signal(*args, **kwargs)
+    def signal(self, path, doc=None):
+        norm_path = data.normalize_path(path)
+        return self.events.signal(norm_path, doc=doc)
 
     def listen(self):
         stream = self._db.child(self._root_path).stream(self._stream_handler)

--- a/firebasedata/watcher.py
+++ b/firebasedata/watcher.py
@@ -78,6 +78,7 @@ def watch(name, should_update, update_func, interval=None):
         return
 
     watcher = Watcher(should_update, update_func, interval)
+    logger.debug('New watcher started %s: %s', name, id(watcher))
     _watchers[name] = watcher
     watcher.start()
 
@@ -87,7 +88,7 @@ def cancel(name):
         return None
     watcher = _watchers[name]
     if watcher:
-        logger.debug('Cancelling watcher: %s (%s)', name, id(watcher))
+        logger.debug('Cancelling watcher %s: %s', name, id(watcher))
         watcher.cancel()
     del _watchers[name]
     return True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FirebaseData',
-    version='0.4',
+    version='0.5',
     packages=find_packages(),
     install_requires=[
         'blinker>=1.4',

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -157,6 +157,11 @@ class Test_signal:
         signal2 = livedata.signal('/foo/bar')
         assert signal1 is signal2
 
+    def test_normalized_signal(self, livedata):
+        signal1 = livedata.signal('/foo/bar/')
+        signal2 = livedata.signal('foo/bar')
+        assert signal1 is signal2
+
     def test_new_signal(self, livedata):
         signal1 = livedata.signal('/foo/bar')
         signal2 = livedata.signal('/foo/bar/baz')


### PR DESCRIPTION
Signal names are always paths. However, when connecting to a signal, the same path may be specified in multiple ways. For example, `/foo/bar/` is the same as `foo/bar` for all intents and purposes. This change normalizes path names when retrieving Signals, to account for such differences.