### PR TITLE
Add metawatcher

### DIFF
--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -38,7 +38,7 @@ class LiveData(object):
             # Fetch data now
             try:
                 value = self._db.child(self._root_path).get().val()
-            except HTTPError as e:
+            except HTTPError:
                 logger.exception('Error getting data')
             else:
                 self._cache = data.FirebaseData(value)
@@ -78,7 +78,7 @@ class LiveData(object):
     def listen(self):
         try:
             stream = self._db.child(self._root_path).stream(self._stream_handler)
-        except HTTPError as e:
+        except HTTPError:
             logger.exception('Error starting stream')
         else:
             self._streams[id(stream)] = stream

--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -76,10 +76,26 @@ class LiveData(object):
             self.restart,
             interval=self._ttl
         )
+        self.cancel_metawatcher()
+
+    def get_metawatcher_name(self):
+        return 'meta_{}'.format(id(self))
+
+    def start_metawatcher(self):
+        watcher.watch(
+            self.get_metawatcher_name(),
+            lambda: self._cache is None,
+            self.get_data,
+            interval=datetime.timedelta(minutes=1)
+        )
+
+    def cancel_metawatcher(self):
+        watcher.cancel(self.get_metawatcher_name())
 
     def restart(self):
         self.reset()
         self.get_data()
+        self.start_metawatcher()
 
     def reset(self):
         logger.debug('Resetting all data')

--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -10,14 +10,17 @@ from . import data
 from . import watcher
 
 logger = logging.getLogger(__name__)
+RETRY_INTERVAL = datetime.timedelta(minutes=1)
 
 
 class LiveData(object):
-    def __init__(self, pyrebase_app, root_path, ttl=None):
+    def __init__(self, pyrebase_app, root_path, ttl=None, retry_interval=None):
         self._app = pyrebase_app
         self._root_path = root_path
         self._ttl = ttl
-        self._retry_interval = datetime.timedelta(minutes=1)
+        self._retry_interval = (
+            RETRY_INTERVAL if retry_interval is None else retry_interval
+        )
         self._db = self._app.database()
         self._streams = {}
         self._gc_streams = queue.Queue()

--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -36,7 +36,7 @@ class LiveData(object):
             try:
                 value = self._db.child(self._root_path).get().val()
             except HTTPError as e:
-                logger.error('Error getting data: %s', e)
+                logger.exception('Error getting data')
             else:
                 self._cache = data.FirebaseData(value)
                 # Listen for updates
@@ -76,7 +76,7 @@ class LiveData(object):
         try:
             stream = self._db.child(self._root_path).stream(self._stream_handler)
         except HTTPError as e:
-            logger.error('Error starting stream: %s', e)
+            logger.exception('Error starting stream')
         else:
             self._streams[id(stream)] = stream
             self._start_stream_gc()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 argh==0.26.2
 attrs==17.4.0
 blinker==1.4
+callee==0.3.1
 certifi==2018.1.18
 chardet==3.0.4
 colorama==0.3.9
@@ -10,6 +11,7 @@ flake8==3.6.0
 idna==2.6
 mccabe==0.6.1
 pathtools==0.1.2
+pkg-resources==0.0.0
 pkginfo==1.4.1
 pluggy==0.6.0
 py==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ flake8==3.6.0
 idna==2.6
 mccabe==0.6.1
 pathtools==0.1.2
-pkg-resources==0.0.0
 pkginfo==1.4.1
 pluggy==0.6.0
 py==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FirebaseData',
-    version='0.5.2',
+    version='0.6.0',
     packages=find_packages(),
     install_requires=[
         'blinker>=1.4',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -148,7 +148,7 @@ def test_connection_recovery(livedata, mocker):
     watch_mock.assert_any_call(
         livedata.get_metawatcher_name(),
         callee.functions.Callable(),
-        livedata.get_data,
+        livedata.get_data_silent,
         interval=livedata._retry_interval
     )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -142,7 +142,7 @@ def test_connection_recovery(livedata, mocker):
     livedata.is_stale = lambda: True
     livedata._db.child = mocker.Mock(side_effect=HTTPError('Test error'))
 
-    result = livedata.restart()
+    livedata.restart()
     time.sleep(3)
 
     watch_mock.assert_any_call(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,9 @@
 import datetime
+import time
 
+import callee
 import pytest
+from urllib3.exceptions import HTTPError
 
 from firebasedata import data, live
 
@@ -125,3 +128,36 @@ def test_signal_propagation__leaf(livedata, firebase_data, mocker):
         path='/foo/bar/baz',
         value='hola'
     )
+
+
+@pytest.mark.slow
+def test_connection_recovery(livedata, mocker):
+    watch_mock = mocker.Mock(wraps=live.watcher.watch)
+    cancel_mock = mocker.Mock(wraps=live.watcher.cancel)
+    live.watcher.watch = watch_mock
+    live.watcher.cancel = cancel_mock
+    livedata._cache = None
+    livedata._ttl = datetime.timedelta(seconds=1)
+    livedata._retry_interval = datetime.timedelta(seconds=2)
+    livedata.is_stale = lambda: True
+    livedata._db.child = mocker.Mock(side_effect=HTTPError('Test error'))
+
+    result = livedata.restart()
+    time.sleep(3)
+
+    watch_mock.assert_any_call(
+        'meta_{}'.format(id(livedata)),
+        callee.functions.Callable(),
+        livedata.get_data,
+        interval=livedata._retry_interval
+    )
+
+    livedata._db.child = mocker.Mock()
+    livedata.is_stale = lambda: False
+
+    time.sleep(3)
+
+    cancel_mock.assert_any_call(
+        'meta_{}'.format(id(livedata))
+    )
+    assert isinstance(livedata._cache, data.FirebaseData)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -146,7 +146,7 @@ def test_connection_recovery(livedata, mocker):
     time.sleep(3)
 
     watch_mock.assert_any_call(
-        'meta_{}'.format(id(livedata)),
+        livedata.get_metawatcher_name(),
         callee.functions.Callable(),
         livedata.get_data,
         interval=livedata._retry_interval

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -70,7 +70,7 @@ class Test_get_data:
         result = livedata.get_data()
 
         assert result is None
-        assert logger.error.called
+        assert logger.exception.called
 
 
 class Test_set_data:
@@ -226,7 +226,7 @@ class Test_listen:
 
         livedata.listen()
 
-        assert logger.error.called
+        assert logger.exception.called
 
 
 class Test_reset:

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -249,6 +249,7 @@ class Test_restart:
             interval=callee.types.InstanceOf(datetime.timedelta)
         )
 
+
 class Test_metawatcher:
     def test_get_metawatcher_name(self, livedata):
         name = livedata.get_metawatcher_name()
@@ -272,6 +273,7 @@ class Test_metawatcher:
         livedata.cancel_metawatcher()
 
         watcher_mock.assert_called_with(name)
+
 
 class Test_hangup:
     def test_cancel_watcher(self, livedata, mocker):

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -242,7 +242,7 @@ class Test_restart:
         watcher_mock = mocker.patch('firebasedata.live.watcher.watch')
         livedata.restart()
 
-        watcher_mock.assert_called_with(
+        watcher_mock.assert_any_call(
             'meta_{}'.format(id(livedata)),
             callee.functions.Callable(),
             livedata.get_data,

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -246,26 +246,24 @@ class Test_reset:
 class Test_restart:
     def test_calls_reset(self, livedata, mocker):
         livedata.reset = mocker.Mock()
+
         livedata.restart()
 
         assert livedata.reset.called
 
-    def test_resets_get_data(self, livedata, mocker):
+    def test_calls_start_metawatcher(self, livedata, mocker):
         livedata.start_metawatcher = mocker.Mock()
+
         livedata.restart()
 
         assert livedata.start_metawatcher.called
 
-    def test_watches_data(self, livedata, mocker):
-        watcher_mock = mocker.patch('firebasedata.live.watcher.watch')
+    def test_calls_get_data(self, livedata, mocker):
+        livedata.get_data = mocker.Mock()
+
         livedata.restart()
 
-        watcher_mock.assert_any_call(
-            'meta_{}'.format(id(livedata)),
-            callee.functions.Callable(),
-            livedata.get_data,
-            interval=callee.types.InstanceOf(datetime.timedelta)
-        )
+        assert livedata.get_data.called
 
 
 class Test_metawatcher:
@@ -278,7 +276,7 @@ class Test_metawatcher:
         livedata.start_metawatcher()
 
         watcher_mock.assert_called_with(
-            'meta_{}'.format(id(livedata)),
+            livedata.get_metawatcher_name(),
             callee.functions.Callable(),
             livedata.get_data,
             interval=callee.types.InstanceOf(datetime.timedelta)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -67,7 +67,13 @@ class Test_get_data:
     def test_connection_error(self, livedata, logger, mocker):
         livedata._db.child = mocker.Mock(side_effect=HTTPError('Test error'))
 
-        result = livedata.get_data()
+        with pytest.raises(HTTPError):
+            livedata.get_data()
+
+    def test_get_data_silent_connection_error(self, livedata, logger, mocker):
+        livedata._db.child = mocker.Mock(side_effect=HTTPError('Test error'))
+
+        result = livedata.get_data_silent()
 
         assert result is None
         assert logger.exception.called
@@ -224,9 +230,8 @@ class Test_listen:
     def test_connection_error(self, livedata, mocker, logger):
         livedata._db.child = mocker.Mock(side_effect=HTTPError('Test error'))
 
-        livedata.listen()
-
-        assert logger.exception.called
+        with pytest.raises(HTTPError):
+            livedata.listen()
 
 
 class Test_reset:
@@ -278,7 +283,7 @@ class Test_metawatcher:
         watcher_mock.assert_called_with(
             livedata.get_metawatcher_name(),
             callee.functions.Callable(),
-            livedata.get_data,
+            livedata.get_data_silent,
             interval=callee.types.InstanceOf(datetime.timedelta)
         )
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -70,8 +70,15 @@ class Test_get_data:
         with pytest.raises(HTTPError):
             livedata.get_data()
 
+    def test_get_data_silent(self, livedata, mocker):
+        livedata.get_data = mocker.Mock()
+
+        livedata.get_data_silent()
+
+        assert livedata.get_data.called
+
     def test_get_data_silent_connection_error(self, livedata, logger, mocker):
-        livedata._db.child = mocker.Mock(side_effect=HTTPError('Test error'))
+        livedata.get_data = mocker.Mock(side_effect=HTTPError('Test error'))
 
         result = livedata.get_data_silent()
 


### PR DESCRIPTION
Add meta watcher to prevent restart stalls

When stale data is detected, we close the current connection and attempt to establish a new one. Currently, if that fails, the app gets wedged. This PR adds a new watcher that checks if the new connection was established successfully and retries every minute until it does.