### PR TITLE
More general exception handling in get_data_silent

### DIFF
--- a/firebasedata/live.py
+++ b/firebasedata/live.py
@@ -4,7 +4,6 @@ import queue
 import threading
 
 from blinker.base import Namespace
-from urllib3.exceptions import HTTPError
 
 from . import data
 from . import watcher
@@ -46,7 +45,7 @@ class LiveData(object):
     def get_data_silent(self):
         try:
             return self.get_data()
-        except HTTPError:
+        except Exception:
             logger.exception('Error getting data')
 
     def set_data(self, path, value):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FirebaseData',
-    version='0.6.0',
+    version='0.6.1',
     packages=find_packages(),
     install_requires=[
         'blinker>=1.4',

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -78,7 +78,7 @@ class Test_get_data:
         assert livedata.get_data.called
 
     def test_get_data_silent_connection_error(self, livedata, logger, mocker):
-        livedata.get_data = mocker.Mock(side_effect=HTTPError('Test error'))
+        livedata.get_data = mocker.Mock(side_effect=OSError('SSL error'))
 
         result = livedata.get_data_silent()
 


### PR DESCRIPTION
Gracefully handle any exception raised in `get_data_silent`, not just `HTTPError`s.