### PR TITLE
Fix bug where default value is not cleared when root is set to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Firebase Live Data
 
-[![Build Status](https://github.com/heston/firebase-live-data/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/heston/firebase-live-data/actions/workflows/pytest.yml?query=branch%3Amaster)
+[![PyPI version](https://badge.fury.io/py/FirebaseData.svg)](https://badge.fury.io/py/FirebaseData)[![Build Status](https://github.com/heston/firebase-live-data/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/heston/firebase-live-data/actions/workflows/pytest.yml?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/heston/firebase-live-data/badge.svg?branch=master)](https://coveralls.io/github/heston/firebase-live-data?branch=master)
 
 Utilities for storing, retrieving, and monitoring Firebase Realtime Database objects in

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Firebase Live Data
 ==================
 
-|Build Status| |Coverage Status|
+|PyPI version| |Build Status| |Coverage Status|
 
 Utilities for storing, retrieving, and monitoring Firebase Realtime
 Database objects in Python.
@@ -12,11 +12,11 @@ push updates throughout the Python stack. It works by linking together
 custom data structure. It allows arbitrary Python code to subscribe to
 notifications whenever data in your Firebase Realtime Database changes.
 
-Q: Can't I just use ``Pyrebase``
+Q: Can’t I just use ``Pyrebase``
 --------------------------------
 
 A: Sure, but if you want to be notified in realtime when your data
-changes, you'll need to set up thread-based stream handlers, and manage
+changes, you’ll need to set up thread-based stream handlers, and manage
 their lifecycles. In addition, the format of events from Firebase can be
 tricky to parse (do you know the difference between Firebase ``PUT`` and
 ``PATCH`` events?)
@@ -24,32 +24,66 @@ tricky to parse (do you know the difference between Firebase ``PUT`` and
 Firebase Live Data abstracts these concepts into simple ``blinker``
 signals that are easy to use.
 
+Installing
+----------
+
+.. code:: bash
+
+   pip install FirebaseData -e git+https://github.com/heston/Pyrebase.git@a77bd6f6def656b1dcd77d938fac2707f3c4ba61#egg=Pyrebase
+
+Dependencies
+------------
+
+Firebase Live Data has a direct dependency on
+`Blinker <https://pypi.python.org/pypi/blinker>`__, and a peer
+dependency on `Pyrebase <https://pypi.python.org/pypi/Pyrebase>`__ (see
+note below). This means that Blinker will be installed automatically,
+while Pyrebase must be installed separately (hence its inclusion in the
+``pip`` command above). This is because Pyrebase requires `additional
+configuration <https://github.com/thisbejim/Pyrebase#add-pyrebase-to-your-application>`__
+that is outside the scope of this document.
+
+**A note on Pyrebase maintenance**: It seems that Pyrebase is no longer
+being actively maintained, unfortunately. Please use `this author’s
+fork <https://github.com/heston/Pyrebase/tree/upgrade-google-auth>`__ to
+get things working:
+
+::
+
+   pip install -e git+https://github.com/heston/Pyrebase.git@a77bd6f6def656b1dcd77d938fac2707f3c4ba61#egg=Pyrebase
+
+Compatibility
+-------------
+
+Firebase Live Data is tested against Python 3.7, 3.8, 3.9 and 3.10. It
+is not compatible with Python 2.
+
 Usage
 -----
 
 .. code:: python
 
-    import pyrebase
+   import pyrebase
 
-    from firebasedata import LiveData
+   from firebasedata import LiveData
 
-    pyrebase_config = {
-        # ...
-    }
+   pyrebase_config = {
+       # ...
+   }
 
-    app = pyrebase.initialize_app(pyrebase_config)
-    live = LiveData(app, '/my_data')
+   app = pyrebase.initialize_app(pyrebase_config)
+   live = LiveData(app, '/my_data')
 
-    # Get a snapshot of all data at the path, `/my_data`.
-    #
-    # This also sets up a persistent push connection to the Firebase Realtime Database
-    # at that path. Any updates under this path will trigger `blinker` events.
-    #
-    # `data` is a local (greedy) cache of the data at the root path (`/my_data`). It behaves
-    # somewhat like a Python dictionary.
-    data = live.get_data()
-    all_data = data.get() #  this also works: data.get('/')
-    sub_data = data.get('my/sub/path')
+   # Get a snapshot of all data at the path, `/my_data`.
+   #
+   # This also sets up a persistent push connection to the Firebase Realtime Database
+   # at that path. Any updates under this path will trigger `blinker` events.
+   #
+   # `data` is a local (greedy) cache of the data at the root path (`/my_data`). It behaves
+   # somewhat like a Python dictionary.
+   data = live.get_data()
+   all_data = data.get() #  this also works: data.get('/')
+   sub_data = data.get('my/sub/path')
 
 The push connection is established lazily, after the first call to
 ``get_data``.
@@ -59,28 +93,26 @@ just connect to the signal at that database path.
 
 .. code:: python
 
-    def my_handler(data):
-        print(data)
+   def my_handler(sender, value=None):
+       print(value)
 
 
-    # Note that the root path (`/my_data` in this case) is omitted from the signal name.
+   # Note that the root path (`/my_data` in this case) is omitted from the signal name.
 
-    live.signal('/some/key').connect(my_handler)
+   live.signal('/some/key').connect(my_handler)
+
+``my_handler`` will be invoked with ``sender`` set to the
+``FirebaseData`` instance, and the ``value`` keyword argument set to the
+value of the key that changed.
 
 You can also set data:
 
 .. code:: python
 
-    live.set_data('my/sub/path', 'my_value')
+   live.set_data('my/sub/path', 'my_value')
 
 ``blinker`` events will be dispatched whenever data is set, either
 locally, like the example above, or via server push events.
-
-Compatibility
--------------
-
-Firebase Live Data is tested against Python 3.7, 3.8, 3.9 and 3.10. It is not
-compatible with Python 2.
 
 Developing
 ----------
@@ -89,14 +121,18 @@ Developing
 
    .. code:: bash
 
-       pip install -r requirements.txt
+      python3 -m venv venv
+      source venv/bin/activate
+      pip install -r requirements.txt
 
 2. Run tests to ensure everything works:
 
    .. code:: bash
 
-       py.test
+      pytest
 
+.. |PyPI version| image:: https://badge.fury.io/py/FirebaseData.svg
+   :target: https://badge.fury.io/py/FirebaseData
 .. |Build Status| image:: https://github.com/heston/firebase-live-data/actions/workflows/pytest.yml/badge.svg?branch=master
    :target: https://github.com/heston/firebase-live-data/actions/workflows/pytest.yml?query=branch%3Amaster
 .. |Coverage Status| image:: https://coveralls.io/repos/github/heston/firebase-live-data/badge.svg?branch=master

--- a/firebasedata/data.py
+++ b/firebasedata/data.py
@@ -92,8 +92,10 @@ class FirebaseData(dict):
         node = self.get_node_for_path(path)
 
         if not node.key:
+            # We're at the root node
             if value is None:
                 node.value.clear()
+                node.value._default_value = None
             else:
                 self._update(node.value, value)
         else:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='FirebaseData',
-    version='0.6.2',
+    version='0.6.3',
     packages=find_packages(),
     install_requires=[
         'blinker>=1.4',

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -223,3 +223,17 @@ class TestFirebaseData_single_value:
         result = data.get('/foo/bar')
 
         assert result == 1
+
+    def test_set_str_initially_then_set_none(self):
+        data = firebase_data.FirebaseData('hello')
+        data.set('/', None)
+        result = data.get()
+
+        assert result is None
+
+    def test_set_dict_initially_then_set_none(self):
+        data = firebase_data.FirebaseData({'foo': 'bar'})
+        data.set('/', None)
+        result = data.get()
+
+        assert result is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -86,6 +86,48 @@ def test_signal_propagation__root(livedata, firebase_data, mocker):
     )
 
 
+def test_signal_propagation__set_root_to_none(livedata, firebase_data, mocker):
+    """Test what happens when the root node is set to None."""
+
+    mock_handler = mocker.MagicMock()
+
+    def handler(*args, **kwargs):
+        mock_handler(*args, **kwargs)
+
+    livedata.signal('/').connect(handler)
+
+    message = {
+        'path': '/',
+        'data': 'hola',
+        'event': 'put',
+    }
+    livedata._stream_handler(message)
+
+    assert firebase_data.get() == 'hola'
+
+    message = {
+        'path': '/',
+        'data': None,
+        'event': 'put',
+    }
+    livedata._stream_handler(message)
+
+    assert firebase_data.get() is None
+
+    mock_handler.assert_has_calls([
+        mocker.call(
+            firebase_data,
+            path='/',
+            value='hola'
+        ),
+        mocker.call(
+            firebase_data,
+            path='/',
+            value=None
+        )
+    ])
+
+
 def test_signal_propagation__node(livedata, firebase_data, mocker):
     mock_handler = mocker.MagicMock()
 


### PR DESCRIPTION
If the root node is set with a single value (i.e. not a `dict`), and then later set to `None`, the previously set single value is not cleared. This results in subsequent calls to get the value returning the previously set single value, not `None` as should happen.